### PR TITLE
Fixes and improvements when running over non nats competitions

### DIFF
--- a/competition.js
+++ b/competition.js
@@ -29,8 +29,11 @@ function listFiles() {
     for (const f of files) {
       if (f.endsWith('.cs')) {
         out.push((dir + '/' + f).substring(2))
-      } else if (fs.lstatSync(process.env.SCRIPT_BASE + '/' + dir + '/' + f)) {
-        dirs.push(dir + '/' + f)
+      } else {
+        stats = fs.lstatSync(process.env.SCRIPT_BASE + '/' + dir + '/' + f);
+        if (stats.isDirectory()) {
+          dirs.push(dir + '/' + f)
+        }
       }
     }
   }

--- a/group.js
+++ b/group.js
@@ -12,7 +12,13 @@ class Group {
 
   name() {
     if (this.activityCode.isActivity()) {
-      return this.room.name.split(' ')[0] + ' ' + this.activityCode.groupNumber
+      // This is not ideal; when displaying room names we'd like to
+      // keep only the meaningful part (eg: "Red" when it's "Red Stage", which
+      // is usually the first part of the name in English, but may be some other
+      // parts in other languages. This is a compromise where we strip out
+      // 'Stage' or 'Room' suffix, which should be enough in "regular" major
+      // competitions setup while not messing up room names in non English setups.
+      return this.room.name.replace(/Room|Stage/g, '').trim() + ' ' + this.activityCode.groupNumber
     } else {
       return this.activityCode.toString()
     }

--- a/parser/parser.js
+++ b/parser/parser.js
@@ -69,6 +69,7 @@ async function parse(text, req, res, ctx, allowParams) {
         }
       })
     }
+    out.outputs.push({ type: 'CompetitionWCIF', data: ctx.competition })
   } catch (e) {
     out.outputs.splice(0, 0, {type: 'Exception', data: e.stack})
     out.mutations = []

--- a/views/dispatch.pug
+++ b/views/dispatch.pug
@@ -64,3 +64,6 @@ mixin dispatch(value)
           +dispatch(data)
     if value.type == 'ListScriptsOutput'
       +list_scripts(value.data)
+    if value.type == 'CompetitionWCIF'
+      a(href=`data:application/json;charset=utf-8,${encodeURIComponent(JSON.stringify(value.data))}`, target='_blank').
+        Open WCIF as JSON in a new tab

--- a/views/groups.pug
+++ b/views/groups.pug
@@ -18,5 +18,9 @@ mixin groups(data)
             td
               a(href='https://wca.link/' + assignment.person.wcaId)= assignment.person.wcaId
             td= assignment.person.countryIso2
-            td= fn.personalBest(assignment.person, data.round).toString()
+            - var pb = fn.personalBest(assignment.person, data.round)
+            if pb
+              td= pb.toString()
+            else
+              td= ""
             td= assignment.set

--- a/views/index.pug
+++ b/views/index.pug
@@ -1,8 +1,8 @@
 html
   head
-    title Nats Helper
+    title Compscript
   body
-    h1 Nats Helper
+    h1 Compscript
     each competition in competitions
       p
         a(href='/'+competition.id)= competition.name

--- a/views/script.pug
+++ b/views/script.pug
@@ -1,7 +1,7 @@
 include dispatch.pug
 html
   head
-    title Nats Helper
+    title Compscript
     style
       include script.css
     link(rel='stylesheet', href='/cubing-icons.css')


### PR DESCRIPTION
I ran into a couple of crashes when running compscript, here is a description of each change:
  - `filename` was not defined and made the app crash on startup; I assume it didn't crash because `req.session.script` was already defined when you introduced it.
  - The competition I used as a sandbox had competitors without results in some events; I chose to return `DNS` in these cases for the PB, but it can be adjusted to keep returning `null` and make sure the caller checks for that case. I'm actually unsure about what would be the impact on the other parts of the code so let me know which fix you'd rather keep.
  - The group name assumes that the room is "X Stage" or "Y Room", whereas in French it's usually "Salle X" (or more generally the specific part we want to keep is last in the sentence); I "fixed" the displayed name to just strip Stage and Room from the name.
  - I added a link to open the JSON in a new tab: firefox has a nice json explorer which is quite handy to inspect the script's result (in addition to the already displayed changes of course), and it can also serve as a quick "backup" link. I had never opened a pug template before this, so let me know if there is a cleaner way to do that!
 Additionally the json is currently set in an attribute and passed in the URL, I have no idea how it will scale with "fullsize" competition and an alternate implementation where it's a file download might be needed.