### PR TITLE
Add functions to Import/Clear/Export the WCIF

### DIFF
--- a/.env.DEV
+++ b/.env.DEV
@@ -9,3 +9,4 @@ USE_CDN=
 API_KEY='example-application-id'
 API_SECRET='example-secret'
 COOKIE_SECRET='b8f6959746b617d9c9e90ce4a4b6e0'
+WCIF_DATA_FOLDER=wcif_data

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ google-credentials.json
 .env.*
 !.env.DEV
 .wcif_cache
+wcif_data
 
 # Logs
 logs

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Node must be installed on your machine.
 
 ```
 $ npm install
-$ ENV=DEV npx nodemon .
+$ npm run dev-server
 ```
 
-`ENV=DEV` uses a dev WCA environment running on the same machine. If you would like to use the production WCA site, you need to:
+Running the development server will use uses a dev WCA environment running on the same machine. If you would like to use the production WCA site, you need to:
 
 1. Make an OAuth application [here](https://www.worldcubeassociation.org/oauth/applications). For "Scopes", use `public manage_competitions`; for "Callback Urls" use `http://localhost:3033/auth/oauth_response`.
 2. Make a copy of the `.env.DEV` file, such as `.env.PROD`. This file should not be committed; `.gitignore` should automatically ignore it.

--- a/functions/functions.js
+++ b/functions/functions.js
@@ -17,5 +17,6 @@ module.exports = {
           require('./tuple').functions,
           require('./udf').functions,
           require('./util').functions,
+          require('./wcif').functions,
       )
 }

--- a/functions/wcif.js
+++ b/functions/wcif.js
@@ -1,0 +1,31 @@
+const fs = require('fs')
+const fse = require('fs-extra')
+
+const ExportWCIF = {
+  name: 'ExportWCIF',
+  docs: 'Export the WCIF to a json file',
+  args: [
+    {
+      name: 'filename',
+      type: 'String',
+      docs: 'WCIF filename (emitted in WCIF_DATA_FOLDER/competitionId)',
+      defaultValue: 'wcif.json',
+    },
+  ],
+  outputType: 'String',
+  usesContext: true,
+  implementation: (ctx, filename) => {
+    var folder = `${process.env.WCIF_DATA_FOLDER || '.'}/${ctx.competition.id}`;
+    var fullPath = `${folder}/${filename}`
+    fse.ensureDirSync(folder)
+    fs.writeFileSync(
+      fullPath,
+      JSON.stringify(ctx.competition, null, 2)
+    )
+    return `WCIF saved to '${fullPath}'.`
+  }
+}
+
+module.exports = {
+  functions: [ExportWCIF],
+}

--- a/functions/wcif.js
+++ b/functions/wcif.js
@@ -43,6 +43,29 @@ const ClearWCIF = {
   }
 }
 
+const ImportWCIF = {
+  name: 'ImportWCIF',
+  docs: 'Import the WCIF from a json file',
+  args: [
+    {
+      name: 'filename',
+      type: 'String',
+      docs: 'WCIF filename (relative to WCIF_DATA_FOLDER/competitionId)',
+    },
+  ],
+  outputType: 'String',
+  usesContext: true,
+  implementation: (ctx, filename) => {
+    var fullPath = `${process.env.WCIF_DATA_FOLDER || '.'}/${ctx.competition.id}/${filename}`
+    var wcif = JSON.parse(fs.readFileSync(fullPath))
+    if (wcif.id !== ctx.competition.id) {
+      throw new Error(`The WCIF is not for the correct competition (expected "${ctx.competition.id}", but got "${wcif.id})"`)
+    }
+    ctx.competition = wcif
+    return `Imported WCIF from '${fullPath}'.`
+  }
+}
+
 const ExportWCIF = {
   name: 'ExportWCIF',
   docs: 'Export the WCIF to a json file',
@@ -69,5 +92,5 @@ const ExportWCIF = {
 }
 
 module.exports = {
-  functions: [ClearWCIF, ExportWCIF],
+  functions: [ClearWCIF, ExportWCIF, ImportWCIF],
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "version": "1.0.0",
   "main": "main.js",
   "scripts": {
+    "dev-server": "ENV=DEV npx nodemon -i wcif_data .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
I wanted to create a pull request on top of #46, but it wouldn't let me open it in this repository because the base branch would have been in my fork too.
Therefore this PR contains all the code from #46; the diff will shrink when #46 is merged, but at the moment I would recommend reviewing this by taking a look at the last 3 commits individually, or going to [the diff between `fixes` and `import-export-wcif`](https://github.com/viroulep/compscript/compare/fixes...viroulep:compscript:import-export-wcif)!

I started by implementing the `ExportWCIF` function, and ran into an expected behavior from `nodemon` I did not see coming, where emitting a json in a subfolder would trigger a rebuild of the application and reset the connection in the browser.
I worked around this by creating a default `OUTPUT_BASE` folder, which I told `nodemon` to ignore through `-i outputs`.
I have created a `dev-server` target in the `package.json` to be able to conveniently run `npm run dev-server` without having to remember the correct command line every time.

As far as the implementation goes it was quite straightforward, but I did not invest into error checking and the tool will just crash if it can't write the file.

The `ImportWCIF` function is quite straightforward too, and load a file relative to `SCRIPT_BASE`.

I also took the liberty of implementing a `ClearWCIF` function: the name may need to be adjusted, since the purpose is not to reset the whole WCIF but basically provide a "clean" WCIF on top of which the script will run (no assignments, no groups, no unexpected extensions).

It's actually awesome just to make sure anything created by another tool is gone.
If I'm not mistaken there is not such a function even for the WCA website admins; you would have to go into rails' console to clean up the WCIF manually (which I believe I've done several times in the past when some competitions' state got messed up).
