### PR TITLE
Add a safeguard to prevent infinite loop

### DIFF
--- a/groups/assign.js
+++ b/groups/assign.js
@@ -99,7 +99,10 @@ function Assign(competition, round, assignmentSets, scorers, stationRules, attem
       }
     })
     var totalToAssign = queue.length
+    var previousLength = -1;
     while (queue.length > preAssignedTotal) {
+      var potentialInfinite = queue.length === previousLength;
+      previousLength = queue.length;
       console.log(queue.length + ' left')
       // Don't assign any more to groups with enough people pre-assigned.
       var groupsToUse = eligibleGroups.filter((group) => currentByGroup[group.wcif.id].length + preAssignedByGroup[group.wcif.id] <= groupSizeLimit)
@@ -135,6 +138,10 @@ function Assign(competition, round, assignmentSets, scorers, stationRules, attem
           }
         })
       })
+      if (!solution.feasible && potentialInfinite) {
+        console.log("The group assignment is not feasible, the function will break out to prevent an infinite loop.")
+        break;
+      }
       queue = queue.filter((item, idx) => !indicesToErase.includes(idx))
       newlyAssigned.forEach((assn) => {
         currentByPerson[assn.person.wcaUserId] = assn.group


### PR DESCRIPTION
Once I messed up group assignments and ended up in an infinite loop because the group assignment solver would not find a solution.
Have you encountered this issue before?

Here I'm not sure about the proper fix: I definitely want compscript to complain if groups are not feasible, but at the same time an infinite loop does not sound good.
For now I've simply added a break with a log, which may not be bothering enough (or let's say one could miss it), do you have a suggestion on how to return a proper error from this part of the code?