### PR TITLE
Add Round(Start|End)Time

### DIFF
--- a/functions/groups.js
+++ b/functions/groups.js
@@ -283,6 +283,48 @@ const StartTime = {
   }
 }
 
+const RoundStartTime = {
+  name: 'RoundStartTime',
+  docs: 'The start time of the first group of a round.',
+  args: [
+    {
+      name: 'round',
+      type: 'Round',
+      canBeExternal: true,
+    },
+  ],
+  outputType: 'DateTime',
+  usesContext: true,
+  implementation: (ctx, round) => {
+    let min = Math.min(
+      ...lib.allActivitiesForRoundId(ctx.competition, round.id())
+            .map(round => lib.startTime(round, ctx.competition).ts)
+    )
+    return min ? DateTime.fromMillis(min).setZone(ctx.competition.schedule.venues[0].timezone) : null
+  }
+}
+
+const RoundEndTime = {
+  name: 'RoundEndTime',
+  docs: 'The end time of the last group of a round.',
+  args: [
+    {
+      name: 'round',
+      type: 'Round',
+      canBeExternal: true,
+    },
+  ],
+  outputType: 'DateTime',
+  usesContext: true,
+  implementation: (ctx, round) => {
+    let max = Math.max(
+      ...lib.allActivitiesForRoundId(ctx.competition, round.id())
+            .map(round => lib.endTime(round, ctx.competition).ts)
+    )
+    return max ? DateTime.fromMillis(max).setZone(ctx.competition.schedule.venues[0].timezone) : null
+  }
+}
+
 const EndTime = {
   name: 'EndTime',
   docs: 'The end time of a group',
@@ -641,6 +683,7 @@ module.exports = {
   functions: [AssignGroups, AssignmentSet, ByMatchingValue, ByFilters, StationAssignmentRule,
               GroupNumber, Stage, AssignedGroup, AssignedGroups,
               GroupName, StartTime, EndTime, Date,
+              RoundStartTime, RoundEndTime,
               AssignmentAtTime, Code, Group, GroupForActivityId, Round, Event, Groups,
               CreateGroups, ManuallyAssign, FixGroupNames, CheckForMissingGroups, FixGroupNumbers],
 }

--- a/lib.js
+++ b/lib.js
@@ -35,6 +35,12 @@ function miscActivityForId(competition, activityId) {
   return null
 }
 
+function allActivitiesForRoundId(competition, roundId) {
+  return competition.schedule.venues.map((venue) => venue.rooms).flat()
+    .map((room) => room.activities.map((activity) => new groupLib.Group(activity, room, competition))).flat()
+    .filter(activity => activity.wcif.activityCode === roundId)
+}
+
 function allGroups(competition) {
   return competition.schedule.venues.map((venue) => venue.rooms).flat()
     .map((room) => {
@@ -69,6 +75,7 @@ module.exports = {
   getWcifRound: getWcifRound,
   personalBest: personalBest,
   allGroups: allGroups,
+  allActivitiesForRoundId: allActivitiesForRoundId,
   groupForActivityId: groupForActivityId,
   groupsForRoundCode: groupsForRoundCode,
   startTime: startTime,


### PR DESCRIPTION
When creating groups for Euros I ended up with a lot of copy/paste and hardcoding of times, whereas I'd like to be able to recreate the groups easily even if I adjust the times slightly later on.

This PR adds `RoundStartTime` and `RoundEndTime`, which enabled me to write stuff like this:

```
Define("MainStages", [
  Tuple(1, "Blue Stage"),
  Tuple(2, "Red Stage"),
  Tuple(3, "Green Stage"),
  Tuple(4, "Orange Stage"),
  Tuple(5, "Yellow Stage")
])

Define("CreateGroupsOnAllStages",
  Map(MainStages(),
    CreateGroups({1, Round}, {2, Number}, Second<Number, String>(),
                 RoundStartTime({1, Round}), RoundEndTime({1, Round}))))

CreateGroupsOnAllStages(_777-r1, 2)
CreateGroupsOnAllStages(_555-r1, 4)
CreateGroupsOnAllStages(_333bf-r1, 3)
CreateGroupsOnAllStages(_666-r1, 3)
CreateGroupsOnAllStages(_minx-r1, 3)
CreateGroupsOnAllStages(_clock-r1, 4)

Define("CreateGroupsOnSide",
    CreateGroups({1, Round}, {2, Number}, "Side Room",
                 RoundStartTime({1, Round}), RoundEndTime({1, Round})))

CreateGroupsOnSide(_333fm-r1-a1, 1)
CreateGroupsOnSide(_333fm-r1-a2, 1)
CreateGroupsOnSide(_333fm-r1-a3, 1)
CreateGroupsOnSide(_333mbf-r1-a1, 1)
```

I could not find an existing function to do something like that, but if I missed it please do let me know :D

Side note: I could not find a way to explicitly refer to the element of the array `Map` is iterating over, and I worked around it by creating a tuple and using `Second`; do you know if I could write something like this and what to use instead of `???`:
```
Define("MainStages", ["Blue Stage", "Red Stage"])
Map(MainStages(), CreateGroups(_333-r1, 2, ???, RoundStartTime(_333-r1), RoundEndTime(_333-r1)))
```