### PR TITLE
Some fixes to group creation

### DIFF
--- a/functions/groups.js
+++ b/functions/groups.js
@@ -516,6 +516,8 @@ const CreateGroups = {
     } else {
       activity = matchingActivities[0]
     }
+    var firstStartTime = null;
+    var lastEndTime = null;
     var length = end.diff(start, 'minutes').as('minutes') / count
     for (var i = 0; i < count; i++) {
       if (skipGroups.includes(i + 1)) {
@@ -534,7 +536,15 @@ const CreateGroups = {
       }
       activity.childActivities.push(next)
       out.push('Added group ' + groupName + ' from ' + next.startTime + ' to ' + next.endTime)
+      if (firstStartTime === null || next.startTime < firstStartTime) {
+        firstStartTime = next.startTime
+      }
+      if (lastEndTime === null || next.endTime > lastEndTime) {
+        lastEndTime = next.endTime
+      }
     }
+    activity.startTime = firstStartTime
+    activity.endTime = lastEndTime
     return out
   }
 }

--- a/functions/groups.js
+++ b/functions/groups.js
@@ -469,12 +469,17 @@ const CreateGroups = {
       name: 'useStageName',
       type: 'Boolean',
       defaultValue: true,
+    },
+    {
+      name: 'createParentIfNotPresent',
+      type: 'Boolean',
+      defaultValue: true,
     }
   ],
   outputType: 'Array<String>',
   usesContext: true,
   mutations: ['schedule'],
-  implementation: (ctx, round, count, stage, start, end, skipGroups, useStageName) => {
+  implementation: (ctx, round, count, stage, start, end, skipGroups, useStageName, createParentIfNotPresent) => {
     var maxActivityId = 0
     ctx.competition.schedule.venues.forEach((venue) => {
       venue.rooms.forEach((room) => {
@@ -501,6 +506,9 @@ const CreateGroups = {
     var out = []
     var activity = null
     if (matchingActivities.length === 0) {
+      if (!createParentIfNotPresent) {
+        return ['Could not find matching activity on schedule.']
+      }
       activity = {
         id: ++maxActivityId,
         activityCode: round.id(),

--- a/parser/driver.js
+++ b/parser/driver.js
@@ -53,7 +53,7 @@ function literalNode(type, value) {
 function dateTimeNode(type, valueStr) {
   return {
     type: { type, params: [] },
-    value: (inParams, ctx) => DateTime.fromISO(valueStr).setZone(ctx.competition.schedule.venues[0].timezone),
+    value: (inParams, ctx) => DateTime.fromISO(valueStr).setZone(ctx.competition.schedule.venues[0].timezone, { keepLocalTime: true }),
     serialize: () => { return { type: type, value: valueStr } },
     mutations: [],
   }


### PR DESCRIPTION
- Allow skipping certain group numbers. This allows e.g. one stage to go
  to lunch early, or come back from lunch late, while following the same
  group numbers as the other stages.

- Add a param for whether to use the stage color, rather than a generic
  "Group", rather than just doing it based on the number of rooms with a
  particular event.

- Allow adding groups without an activity already existing. The goal is
  to allow the script to encode the whole schedule, rather than needing
  to first set it in the GUI and then in a script.

- Correctly convert datetime literals to the venue timezone.