### PR TITLE
Add an Arg<>() function.

### DIFF
--- a/functions/util.js
+++ b/functions/util.js
@@ -24,7 +24,7 @@ const Type = {
 
 const Arg = {
   name: 'Arg',
-  docs: 'A function to capture arguments that are passed in, for example in a user-defined function or Map().'
+  docs: 'A function to capture arguments that are passed in, for example in a user-defined function or Map().',
   genericParams: ['T'],
   args: [
     {

--- a/functions/util.js
+++ b/functions/util.js
@@ -22,6 +22,21 @@ const Type = {
   implementation: (generics, arg) => generics.T
 }
 
+const Arg = {
+  name: 'Arg',
+  docs: 'A function to capture arguments that are passed in, for example in a user-defined function or Map().'
+  genericParams: ['T'],
+  args: [
+    {
+      name: 'arg',
+      type: '$T',
+      canBeExternal: true,
+    },
+  ],
+  outputType: '$T',
+  implementation: (arg) => arg
+}
+
 const ToString = {
   name: 'ToString',
   genericParams: ['T'],
@@ -362,5 +377,5 @@ const AssignmentReport = {
 }
 
 module.exports = {
-  functions: [Type, ClearCache, SetExtension, SetGroupExtension, RenameAssignments, AssignmentsBeforeCompeting, CreateAssignments, AssignmentReport, ToString, SwapAssignments, DeleteAssignments],
+  functions: [Type, Arg, ClearCache, SetExtension, SetGroupExtension, RenameAssignments, AssignmentsBeforeCompeting, CreateAssignments, AssignmentReport, ToString, SwapAssignments, DeleteAssignments],
 }


### PR DESCRIPTION
This is intended to capture arguments in functions like `Map`, rather than using canBeExternal profusely.

This allows things like:

`Map(["a", "b", "c"], (Arg<String>() + "def"))`

It also allows behavior like this for user-defined functions, which cannot use canBeExternal.

@viroulep I'm curious for your thoughts on this! I'm thinking of getting rid of canBeExternal from every other function and just using this instead, since it's more explicit and clearer. See https://github.com/cubingusa/nats-scripts/blob/main/2024/staff_teams.cs#L23 for an example of Arg<>() in action (note also that this is the only way to use a user-defined function like CanScramble in a loop).

I think `canBeExternal` is one of the most confusing and poorly-named features of compscript, and this might help.