### PR TITLE
Cast the assigned staff team to a number.

### DIFF
--- a/cluster/cluster.js
+++ b/cluster/cluster.js
@@ -79,7 +79,7 @@ function Cluster(name, numClusters, persons, preCluster, constraints) {
       if (!ext.properties) {
         ext.properties = {}
       }
-      ext.properties[name] = cluster
+      ext.properties[name] = +cluster
       out.clusters[cluster].persons.push(personOut)
     }
   }


### PR DESCRIPTION
This is currently setting it to a string of the number.

Fixes #39.