### PR TITLE
Change Stage() to return the full stage name.

### DIFF
--- a/functions/groups.js
+++ b/functions/groups.js
@@ -193,7 +193,7 @@ const Stage = {
     }
   ],
   outputType: 'String',
-  implementation: (group) => group.room.name.split(' ')[0]
+  implementation: (group) => group.room.name
 }
 
 const AssignedGroup = {


### PR DESCRIPTION
This is a breaking change. The motivation is that it's confusing to have two versions of a stage name floating around -- the full name and the short name.

@viroulep I'd appreciate your thoughts on this!