### PR TITLE
Make UDF arg handling more resilient.

### DIFF
--- a/parser/driver.js
+++ b/parser/driver.js
@@ -77,20 +77,22 @@ function dateTimeNode(type, valueStr) {
   }
 }
 
-function recursivelySubstituteUdfArgs(impl, udfArgs) {
+function recursivelySubstituteUdfArgs(udf, impl, udfArgs) {
   if (impl.type === 'UdfArg' || impl.type === 'SavedUdfArg') {
+    if (udfArgs.length <= impl.argNum) {
+      throw new Error('Not enough arguments provided to ' + udf.name)
+    }
     return udfArgs[impl.argNum - 1]
   }
   if (impl.args !== undefined) {
-    impl.args = impl.args.map((arg) => recursivelySubstituteUdfArgs(arg, udfArgs))
+    impl.args = impl.args.map((arg) => recursivelySubstituteUdfArgs(udf, arg, udfArgs))
   }
   return impl
 }
 
 function udfNode(udf, ctx, args, allowParams) {
-  // TODO: check the arguments.
   var impl = JSON.parse(JSON.stringify(udf.impl))
-  var out = parseNode(recursivelySubstituteUdfArgs(impl, args), ctx, allowParams)
+  var out = parseNode(recursivelySubstituteUdfArgs(udf, impl, args), ctx, allowParams)
   out.serialize = () => {
     return {
       type: 'Function',

--- a/parser/driver.js
+++ b/parser/driver.js
@@ -79,7 +79,7 @@ function dateTimeNode(type, valueStr) {
 
 function recursivelySubstituteUdfArgs(udf, impl, udfArgs) {
   if (impl.type === 'UdfArg' || impl.type === 'SavedUdfArg') {
-    if (udfArgs.length <= impl.argNum) {
+    if (udfArgs.length < impl.argNum) {
       throw new Error('Not enough arguments provided to ' + udf.name)
     }
     return udfArgs[impl.argNum - 1]


### PR DESCRIPTION
This is done by substituting UDF args at the time the implementation
tree is copied from ctx.udfs, rather than holding onto ctx.udfArgs and
substituting them when we get to that argument. There are too many
special cases, such as lazy evaluation and recursively calling UDFs from
inside one another, where this does not work.