### PR TITLE
Reorder groups in group assignments.

### DIFF
--- a/groups/assign.js
+++ b/groups/assign.js
@@ -5,6 +5,7 @@ const lib = require('./../lib')
 
 function Assign(competition, round, assignmentSets, scorers, stationRules, attemptNumber, override) {
   var groups = lib.groupsForRoundCode(competition, round)
+  groups.sort((g1, g2) => g1.activityCode.groupNumber - g2.activityCode.groupNumber)
   if (attemptNumber !== null) {
     groups = groups.filter((group) => group.activityCode.attemptNumber === attemptNumber)
   }


### PR DESCRIPTION
When assigning groups, change the ordering from:

blue 1, blue 2, blue 3, blue 4, ..., red 1, red 2, ...

to

blue 1, red 1, blue 2, red 2, ...

The fastest people are assigned deterministically following the psych sheet based on the group ordering. In the current version, the top N people are all assigned to the blue stage; with this PR, they alternate blue and red. This will help us with crowd control -- people will be spread across the red and blue stages to see (Yiheng + Tymon) or (Max + Luke), rather than everyone trying to watch on one stage.

@viroulep any concerns about this change?