### PR TITLE
Change staff unavailability implementation.

### DIFF
--- a/functions/staff.js
+++ b/functions/staff.js
@@ -36,12 +36,17 @@ const AssignStaff = {
       type: 'Boolean',
       defaultValue: true,
     },
+    {
+      name: 'unavailable',
+      type: 'Array<StaffUnavailability>(Person)',
+      lazy: true,
+    }
   ],
   outputType: 'StaffAssignmentResult',
   usesContext: true,
   mutations: ['persons'],
-  implementation: (ctx, round, groupFilter, persons, jobs, scorers, overwrite, avoidConflicts) => {
-    return assign.Assign(ctx, round, groupFilter, persons, jobs, scorers, overwrite || ctx.dryrun, avoidConflicts)
+  implementation: (ctx, round, groupFilter, persons, jobs, scorers, overwrite, avoidConflicts, unavailable) => {
+    return assign.Assign(ctx, round, groupFilter, persons, jobs, scorers, overwrite || ctx.dryrun, avoidConflicts, unavailable)
   }
 }
 
@@ -273,31 +278,6 @@ const FollowingGroupScorer = {
   }
 }
 
-const SetStaffUnavailable = {
-  name: 'SetStaffUnavailable',
-  docs: 'Marks the provided staff members as unavailable at the given time',
-  args: [
-    {
-      name: 'persons',
-      type: 'Array<Person>',
-    },
-    {
-      name: 'times',
-      type: 'Array<StaffUnavailability>',
-      serialized: true,
-    }
-  ],
-  outputType: 'String',
-  mutations: ['persons'],
-  implementation: (persons, times) => {
-    persons.forEach((person) => {
-      const ext = extension.getOrInsertExtension(person, 'Person')
-      ext.staffUnavailable = { implementation: times }
-    })
-    return 'Set unavailable for ' + persons.map((person) => person.name).join(', ')
-  }
-}
-
 const UnavailableBetween = {
   name: 'UnavailableBetween',
   docs: 'Indicates that the staff member is unavailable at the given time',
@@ -395,6 +375,6 @@ module.exports = {
               JobCountScorer, PreferenceScorer,
               SameJobScorer, ConsecutiveJobScorer, MismatchedStationScorer,
               ScrambleSpeedScorer, GroupScorer, FollowingGroupScorer,
-              SetStaffUnavailable, UnavailableBetween, UnavailableForDate, BeforeTimes, DuringTimes,
+              UnavailableBetween, UnavailableForDate, BeforeTimes, DuringTimes,
               NumJobs],
 }


### PR DESCRIPTION
Currently this is implemented via setting extensions on the Person. However, extensions are a bit unwieldy, and in particular this behaves badly with UDFs. If you say

Define("Foo", ...)
SetStaffUnavailable([2005REYN01], Foo())

then that Define needs to be run again before you can call AssignStaff, otherwise Foo() is an unknown name.

@viroulep are you using SetStaffUnavailable? This is a breaking change, let me know if you have concerns!