### PR TITLE
Prior assignment scorer

### DIFF
--- a/functions/staff.js
+++ b/functions/staff.js
@@ -153,8 +153,9 @@ const PriorAssignmentScorer = {
     },
   ],
   outputType: 'AssignmentScorer',
-  implementation: (staffingWeight, competingWeight, startTime) => {
-    return new scorers.PriorAssignmentScorer(staffingWeight, competingWeight, startTime)
+  usesContext: true,
+  implementation: (ctx, staffingWeight, competingWeight, startTime) => {
+    return new scorers.PriorAssignmentScorer(ctx.competition, staffingWeight, competingWeight, startTime)
   }
 }
 

--- a/functions/staff.js
+++ b/functions/staff.js
@@ -132,6 +132,32 @@ const JobCountScorer = {
   },
 }
 
+const PriorAssignmentScorer = {
+  name: 'PriorAssignmentScorer',
+  args: [
+    {
+      name: 'staffingWeight',
+      type: 'Number',
+      description: 'Weight added per hour previously spent staffing.',
+    },
+    {
+      name: 'competingWeight',
+      type: 'Number',
+      description: 'Weight added per hour previously spent competing.',
+    },
+    {
+      name: 'startTime',
+      type: 'DateTime',
+      defaultValue: null,
+      nullable: true,
+    },
+  ],
+  outputType: 'AssignmentScorer',
+  implementation: (staffingWeight, competingWeight, startTime) => {
+    return new scorers.PriorAssignmentScorer(staffingWeight, competingWeight, startTime)
+  }
+}
+
 const PreferenceScorer = {
   name: 'PreferenceScorer',
   args: [
@@ -373,7 +399,7 @@ const NumJobs = {
 
 module.exports = {
   functions: [AssignStaff, AssignMisc, Job,
-              JobCountScorer, PreferenceScorer,
+              JobCountScorer, PriorAssignmentScorer, PreferenceScorer,
               SameJobScorer, ConsecutiveJobScorer, MismatchedStationScorer,
               ScrambleSpeedScorer, GroupScorer, FollowingGroupScorer,
               UnavailableBetween, UnavailableForDate, BeforeTimes, DuringTimes,

--- a/staff/scorers.js
+++ b/staff/scorers.js
@@ -15,24 +15,24 @@ class JobCountScorer {
 }
 
 class PriorAssignmentScorer {
-  constructor(staffingWeight, competingWeight, startTime) {
+  constructor(competition, staffingWeight, competingWeight, startTime) {
     this.staffingWeight = staffingWeight
     this.competingWeight = competingWeight
     this.startTime = startTime
     this.name = 'PriorAssignmentScorer'
+    this.groupsById = Object.fromEntries(lib.allGroups(competition).map((g) => [g.wcif.id, g]))
   }
 
   Score(competition, person, group) {
-    var groupsById = Object.fromEntries(lib.allGroups(competition).map((g) => [g.id, g]))
     var staffingHours = 0
     var competingHours = 0
     var startTime = lib.startTime(group, competition)
     for (const assignment of person.assignments) {
       var otherGroup = null
-      if (assignment.activityId in groupsById) {
-        otherGroup = groupsById[assignment.activityId]
+      if (assignment.activityId in this.groupsById) {
+        otherGroup = this.groupsById[assignment.activityId]
       } else {
-        otherGroup = miscActivityForId(assignment.activityId)
+        otherGroup = lib.miscActivityForId(competition, assignment.activityId)
       }
       if (otherGroup !== null) {
         var otherStart = lib.startTime(otherGroup, competition)
@@ -47,7 +47,7 @@ class PriorAssignmentScorer {
         }
       }
     }
-    return this.staffingWeight * staffingHours + this.competingHours * competingHours
+    return this.staffingWeight * staffingHours + this.competingWeight * competingHours
   }
 }
 

--- a/staff/scorers.js
+++ b/staff/scorers.js
@@ -14,6 +14,43 @@ class JobCountScorer {
   }
 }
 
+class PriorAssignmentScorer {
+  constructor(staffingWeight, competingWeight, startTime) {
+    this.staffingWeight = staffingWeight
+    this.competingWeight = competingWeight
+    this.startTime = startTime
+    this.name = 'PriorAssignmentScorer'
+  }
+
+  Score(competition, person, group) {
+    var groupsById = Object.fromEntries(lib.allGroups(competition).map((g) => [g.id, g]))
+    var staffingHours = 0
+    var competingHours = 0
+    var startTime = lib.startTime(group, competition)
+    for (const assignment of person.assignments) {
+      var otherGroup = null
+      if (assignment.activityId in groupsById) {
+        otherGroup = groupsById[assignment.activityId]
+      } else {
+        otherGroup = miscActivityForId(assignment.activityId)
+      }
+      if (otherGroup !== null) {
+        var otherStart = lib.startTime(otherGroup, competition)
+        var otherEnd = lib.endTime(otherGroup, competition)
+        if (otherStart < startTime && (this.startTime === null || otherStart > this.startTime)) {
+          var hours = otherEnd.diff(otherStart, 'hours').as('hours')
+          if (assignment.assignmentCode.startsWith('staff-')) {
+            staffingHours += hours
+          } else {
+            competingHours += hours
+          }
+        }
+      }
+    }
+    return this.staffingWeight * staffingHours + this.competingHours * competingHours
+  }
+}
+
 class PreferenceScorer {
   constructor(weight, prefix, prior, allJobs) {
     this.weight = weight
@@ -88,12 +125,9 @@ class PrecedingAssignmentsScorer {
       assignment = PrecedingAssignment(person, nextGroup, this.groupsById)
     }
     var totalTime = endTime.diff(startTime, 'minutes').minutes
-    //console.log('For person ' + person.name + ' ' + group.activityCode + ' ' + job + ' totalTime: ' + totalTime + ' center: ' + this.center)
     if (totalTime > this.center) {
-      //console.log('over-score ' + (totalTime - this.center) / this.center * this.posWeight)
       return (totalTime - this.center) / this.center * this.posWeight
     } else {
-      //console.log('under-score ' + (this.center - totalTime) / this.center * this.negWeight)
       return (this.center - totalTime) / this.center * this.negWeight
     }
   }
@@ -180,6 +214,7 @@ class FollowingGroupScorer {
 
 module.exports = {
   JobCountScorer: JobCountScorer,
+  PriorAssignmentScorer: PriorAssignmentScorer,
   PreferenceScorer: PreferenceScorer,
   PrecedingAssignmentsScorer: PrecedingAssignmentsScorer,
   MismatchedStationScorer: MismatchedStationScorer,


### PR DESCRIPTION
Rather than replacing JobCountScorer, I'm leaving that as a simpler option and committing this as a more nuanced option, allowing us to score based on the amount of time spent competing and judging prior to this assignment, with different weights for each.

For NAC I'm planning on using weights -4 and -1 (i.e. 1 hour spent staffing is worth -4 points; 1 hour spent competing is worth -1 point). Staff who compete a lot shouldn't get a ton less work than others, but there should be some relief, otherwise they are exhausted by the end of the weekend.

I'm also doing this per-day, to not overly correct for someone who has less work on Thursday (or no work, as there are some excused absences).