### PR TITLE
Modifications to staff scorers:

### DIFF
--- a/functions/staff.js
+++ b/functions/staff.js
@@ -201,13 +201,19 @@ const SameJobScorer = {
       name: 'negWeight',
       type: 'Number',
     },
+    {
+      name: 'jobs',
+      type: 'Array<String>',
+      nullable: true,
+      defaultValue: null,
+    }
   ],
   outputType: 'AssignmentScorer',
   usesContext: true,
-  implementation: (ctx, center, posWeight, negWeight) => {
+  implementation: (ctx, center, posWeight, negWeight, jobs) => {
     return new scorers.PrecedingAssignmentsScorer(
         ctx.competition, center, posWeight, negWeight,
-        (assignment, job) => assignment.assignmentCode === 'staff-' + job)
+        (assignment, job) => assignment.assignmentCode === 'staff-' + job, jobs)
   },
 }
 
@@ -226,13 +232,19 @@ const ConsecutiveJobScorer = {
       name: 'negWeight',
       type: 'Number',
     },
+    {
+      name: 'jobs',
+      type: 'Array<String>',
+      nullable: true,
+      defaultValue: null,
+    }
   ],
   outputType: 'AssignmentScorer',
   usesContext: true,
-  implementation: (ctx, center, posWeight, negWeight) => {
+  implementation: (ctx, center, posWeight, negWeight, jobs) => {
     return new scorers.PrecedingAssignmentsScorer(
         ctx.competition, center, posWeight, negWeight,
-        (assignment, job) => assignment.assignmentCode !== 'competitor')
+        (assignment, job) => assignment.assignmentCode !== 'competitor', jobs)
   },
 }
 
@@ -251,8 +263,8 @@ const MismatchedStationScorer = {
   },
 }
 
-const ScrambleSpeedScorer = {
-  name: 'ScrambleSpeedScorer',
+const SolvingSpeedScorer = {
+  name: 'SolvingSpeedScorer',
   args: [
     {
       name: 'event',
@@ -265,11 +277,15 @@ const ScrambleSpeedScorer = {
     {
       name: 'weight',
       type: 'Number',
+    },
+    {
+      name: 'jobs',
+      type: 'Array<String>',
     }
   ],
   outputType: 'AssignmentScorer',
-  implementation: (event, maxTime, weight) => {
-    return new scorers.ScrambleSpeedScorer(event, maxTime, weight)
+  implementation: (event, maxTime, weight, jobs) => {
+    return new scorers.SolvingSpeedScorer(event, maxTime, weight, jobs)
   }
 }
 
@@ -435,7 +451,7 @@ module.exports = {
   functions: [AssignStaff, AssignMisc, Job,
               JobCountScorer, PriorAssignmentScorer, PreferenceScorer,
               SameJobScorer, ConsecutiveJobScorer, MismatchedStationScorer,
-              ScrambleSpeedScorer, GroupScorer, FollowingGroupScorer,
+              SolvingSpeedScorer, GroupScorer, FollowingGroupScorer,
               UnavailableBetween, UnavailableForDate, BeforeTimes, DuringTimes,
               NumJobs, LengthOfJobs],
 }

--- a/staff/scorers.js
+++ b/staff/scorers.js
@@ -101,7 +101,7 @@ function PrecedingAssignment(person, group, groupsById) {
 }
 
 class PrecedingAssignmentsScorer {
-  constructor(competition, center, posWeight, negWeight, assignmentFilter) {
+  constructor(competition, center, posWeight, negWeight, assignmentFilter, jobs) {
     this.center = center
     this.posWeight = posWeight
     this.negWeight = negWeight
@@ -109,9 +109,13 @@ class PrecedingAssignmentsScorer {
     this.groupsById = Object.fromEntries(lib.allGroups(competition).map((g) => [g.wcif.id, g]))
     this.caresAboutStations = false
     this.caresAboutJobs = true
+    this.jobs = jobs
   }
 
   Score(competition, person, group, job, stationNumber) {
+    if (!(this.jobs || []).includes(job)) {
+      return 0
+    }
     var assignment = PrecedingAssignment(person, group, this.groupsById)
     if (assignment === null || !this.assignmentFilter(assignment, job)) {
       return 0
@@ -152,25 +156,26 @@ class MismatchedStationScorer {
   }
 }
 
-class ScrambleSpeedScorer {
-  constructor(event, maxTime, weight) {
+class SolvingSpeedScorer {
+  constructor(event, maxTime, weight, jobs) {
     this.event = event
     this.maxTime = maxTime
     this.weight = weight
+    this.jobs = jobs
     this.caresAboutStations = false
     this.caresAboutJobs = true
-    this.name = 'ScrambleSpeedScorer'
+    this.name = 'SolvingSpeedScorer'
   }
 
   Score(competition, person, group, job) {
-    if (job !== 'scrambler') {
+    if (!(this.jobs || []).includes(job)) {
       return 0
     }
     var pr = lib.personalBest(person, this.event)
     if (pr > this.maxTime || pr == null) {
       return 0
     }
-    return -1 * this.weight * pr.value / this.maxTime
+    return this.weight * (1 - pr.value / this.maxTime)
   }
 }
 
@@ -218,7 +223,7 @@ module.exports = {
   PreferenceScorer: PreferenceScorer,
   PrecedingAssignmentsScorer: PrecedingAssignmentsScorer,
   MismatchedStationScorer: MismatchedStationScorer,
-  ScrambleSpeedScorer: ScrambleSpeedScorer,
+  SolvingSpeedScorer: SolvingSpeedScorer,
   GroupScorer: GroupScorer,
   FollowingGroupScorer: FollowingGroupScorer,
 }


### PR DESCRIPTION
* Rename ScrambleSpeedScorer to SolvingSpeedScorer
* Add a parameter to SolvingSpeedScorer for which jobs it applies to
 
These two are breaking changes. The motivation is to apply the same scorer to commentators, i.e. faster people at that event should be favored for commentating.

* Add an optional jobs param to two other scorers.

@viroulep since this is a breaking change, can you take a look?