### PR TITLE
Default unavailable to [].

### DIFF
--- a/staff/assign.js
+++ b/staff/assign.js
@@ -56,7 +56,7 @@ function AssignImpl(ctx, activities, persons, jobs, scorers, overwrite, name, av
 
   var unavailableByPerson = {}
   persons.forEach((person) => {
-    unavailableByPerson[person.wcaUserId] = unavailable({Person: person})
+    unavailableByPerson[person.wcaUserId] = unavailable({Person: person}) || []
   })
 
   activities.forEach((activity, idx) => {


### PR DESCRIPTION
I don't know why but sometimes this is returning an empty string.

Workaround for #117